### PR TITLE
修复无法全量导入导出的问题

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -28,9 +28,13 @@
 
     function closeDialog() { overlay.remove(); }
     overlay.addEventListener('click', e => { if (e.target === overlay) closeDialog(); });
-    document.getElementById('_reset_cancel').onclick = closeDialog;
+    const _resetCancelBtn = document.getElementById('_reset_cancel');
+    const _resetCurrentBtn = document.getElementById('_reset_current');
+    const _resetAllBtn = document.getElementById('_reset_all');
 
-    document.getElementById('_reset_current').onclick = () => {
+    if (_resetCancelBtn) _resetCancelBtn.onclick = closeDialog;
+
+    if (_resetCurrentBtn) _resetCurrentBtn.onclick = () => {
         closeDialog();
         if (confirm('确定要清除当前会话的所有消息吗？此操作无法恢复！')) {
             messages = [];
@@ -49,7 +53,7 @@
         }
     };
 
-    document.getElementById('_reset_all').onclick = () => {
+    if (_resetAllBtn) _resetAllBtn.onclick = () => {
         closeDialog();
         if (confirm('【高危操作】确定要重置所有数据吗？此操作将清除所有本地数据且无法恢复！')) {
             window._skipBackup = true;
@@ -1706,14 +1710,16 @@ function showModal(modalElement, focusElement = null) {
 
             function closeDialog() { overlay.remove(); }
             overlay.addEventListener('click', e => { if (e.target === overlay) closeDialog(); });
-            document.getElementById('_exp_cancel').onclick = closeDialog;
+            const _expCancelBtn = document.getElementById('_exp_cancel');
+            const _expConfirmBtn = document.getElementById('_exp_confirm');
+            if (_expCancelBtn) _expCancelBtn.onclick = closeDialog;
 
-            document.getElementById('_exp_confirm').onclick = function() {
-                const inclMsgs     = document.getElementById('_exp_msgs').checked;
-                const inclSettings = document.getElementById('_exp_settings').checked;
-                const inclReplies  = document.getElementById('_exp_replies').checked;
-                const inclAnn      = document.getElementById('_exp_ann').checked;
-                const inclThemes   = document.getElementById('_exp_themes').checked;
+            if (_expConfirmBtn) _expConfirmBtn.onclick = function() {
+                const inclMsgs     = !!document.getElementById('_exp_msgs')?.checked;
+                const inclSettings = !!document.getElementById('_exp_settings')?.checked;
+                const inclReplies  = !!document.getElementById('_exp_replies')?.checked;
+                const inclAnn      = !!document.getElementById('_exp_ann')?.checked;
+                const inclThemes   = !!document.getElementById('_exp_themes')?.checked;
 
                 if (!inclMsgs && !inclSettings && !inclReplies && !inclAnn && !inclThemes) {
                     showNotification('请至少选择一项导出内容', 'error');
@@ -1858,14 +1864,16 @@ function showModal(modalElement, focusElement = null) {
 
                     function closeDialog() { overlay.remove(); }
                     overlay.addEventListener('click', ev => { if (ev.target === overlay) closeDialog(); });
-                    document.getElementById('_imp_cancel').onclick = closeDialog;
+                    const _impCancelBtn = document.getElementById('_imp_cancel');
+                    const _impConfirmBtn = document.getElementById('_imp_confirm');
+                    if (_impCancelBtn) _impCancelBtn.onclick = closeDialog;
 
-                    document.getElementById('_imp_confirm').onclick = function() {
-                        const doMsgs     = hasMessages  && document.getElementById('_imp_msgs')?.checked;
-                        const doSettings = hasSettings  && document.getElementById('_imp_settings')?.checked;
-                        const doReplies  = hasReplies   && document.getElementById('_imp_replies')?.checked;
-                        const doAnn      = hasAnn       && document.getElementById('_imp_ann')?.checked;
-                        const doThemes   = hasThemes    && document.getElementById('_imp_themes')?.checked;
+                    if (_impConfirmBtn) _impConfirmBtn.onclick = function() {
+                        const doMsgs     = hasMessages  && !!document.getElementById('_imp_msgs')?.checked;
+                        const doSettings = hasSettings  && !!document.getElementById('_imp_settings')?.checked;
+                        const doReplies  = hasReplies   && !!document.getElementById('_imp_replies')?.checked;
+                        const doAnn      = hasAnn       && !!document.getElementById('_imp_ann')?.checked;
+                        const doThemes   = hasThemes    && !!document.getElementById('_imp_themes')?.checked;
 
                         if (!doMsgs && !doSettings && !doReplies && !doAnn && !doThemes) {
                             showNotification('请至少选择一项导入内容', 'error');

--- a/js/features/group-chat.js
+++ b/js/features/group-chat.js
@@ -309,9 +309,11 @@ if (exportAllBtn) {
 
             function closeBkDialog() { overlay.remove(); }
             overlay.addEventListener('click', ev => { if (ev.target === overlay) closeBkDialog(); });
-            document.getElementById('_bk_cancel').onclick = closeBkDialog;
+            const bkCancelBtn = document.getElementById('_bk_cancel');
+            const bkConfirmBtn = document.getElementById('_bk_confirm');
+            if (bkCancelBtn) bkCancelBtn.onclick = closeBkDialog;
 
-            document.getElementById('_bk_confirm').onclick = async function() {
+            if (bkConfirmBtn) bkConfirmBtn.onclick = async function() {
                 const inclMsgs    = document.getElementById('_bk_msgs').checked;
                 const inclSet     = document.getElementById('_bk_settings').checked;
                 const inclCustom  = document.getElementById('_bk_custom').checked;

--- a/js/features/group-chat.js
+++ b/js/features/group-chat.js
@@ -329,8 +329,8 @@ if (exportAllBtn) {
                 closeBkDialog();
 
                 try {
-                    if (typeof ChatBackup !== 'undefined' && ChatBackup.exportBackupToFile) {
-                        await ChatBackup.exportBackupToFile({
+                    if (typeof ChatBackup !== 'undefined' && ChatBackup.buildBackupPayload && ChatBackup.serializeBackupV4) {
+                        const payload = await ChatBackup.buildBackupPayload({
                             inclMsgs: inclMsgs,
                             inclSet: inclSet,
                             inclCustom: inclCustom,
@@ -339,8 +339,14 @@ if (exportAllBtn) {
                             inclDg: inclDg,
                             inclStickers: inclStickers
                         });
+                        const jsonString = ChatBackup.serializeBackupV4(payload);
+                        const dateStr = new Date().toISOString().slice(0, 10);
+                        const fileName = `chatapp-backup-${dateStr}.json`;
+                        const blob = new Blob([jsonString], { type: 'application/json;charset=utf-8' });
+                        downloadFileFallback(blob, fileName);
+                        if (typeof showNotification === 'function') showNotification('已导出 JSON 备份', 'success');
                     } else {
-                        if (typeof showNotification === 'function') showNotification('备份模块未加载，请刷新页面', 'error');
+                        if (typeof showNotification === 'function') showNotification('备份模块或函数未加载，请刷新页面', 'error');
                     }
                 } catch(e) {
                     console.error('全量备份导出失败:', e);

--- a/js/features/mood.js
+++ b/js/features/mood.js
@@ -778,8 +778,10 @@ function _showMoodImportPicker(data) {
     `;
 
     overlay.addEventListener('click', (e) => { if (e.target === overlay) overlay.remove(); });
-    document.getElementById('mood-imp-cancel').onclick = () => overlay.remove();
-    document.getElementById('mood-imp-confirm').onclick = () => {
+    const moodImpCancelBtn = document.getElementById('mood-imp-cancel');
+    const moodImpConfirmBtn = document.getElementById('mood-imp-confirm');
+    if (moodImpCancelBtn) moodImpCancelBtn.onclick = () => overlay.remove();
+    if (moodImpConfirmBtn) moodImpConfirmBtn.onclick = () => {
         const selCal = document.getElementById('mood-imp-cal').checked;
         const selCustom = document.getElementById('mood-imp-custom').checked;
         const selTrash = document.getElementById('mood-imp-trash').checked;

--- a/js/listeners.js
+++ b/js/listeners.js
@@ -1900,9 +1900,12 @@ const savedCover = safeGetItem(APP_PREFIX + 'playerCover');
 
             const closeOpt = () => overlay.remove();
             overlay.addEventListener('click', (ev) => { if(ev.target === overlay) closeOpt(); });
-            document.getElementById('_pl_opt_cancel').onclick = closeOpt;
+            const plOptCancelBtn = document.getElementById('_pl_opt_cancel');
+            const plOptExportBtn = document.getElementById('_pl_opt_export');
+            const plOptImportBtn = document.getElementById('_pl_opt_import');
+            if (plOptCancelBtn) plOptCancelBtn.onclick = closeOpt;
 
-            document.getElementById('_pl_opt_export').onclick = () => {
+            if (plOptExportBtn) plOptExportBtn.onclick = () => {
                 closeOpt();
                 if (songs.length === 0) {
                     showNotification('歌单为空，无法导出', 'warning');
@@ -1920,7 +1923,7 @@ const savedCover = safeGetItem(APP_PREFIX + 'playerCover');
                 showNotification('歌单导出成功', 'success');
             };
 
-            document.getElementById('_pl_opt_import').onclick = () => {
+            if (plOptImportBtn) plOptImportBtn.onclick = () => {
                 closeOpt();
                 const input = header.querySelector('#pl-import-input');
                 if (input) input.click();

--- a/js/utils.js
+++ b/js/utils.js
@@ -446,7 +446,6 @@ async function importAllData(file) {
                 ">
                     <div style="width:36px;height:4px;border-radius:2px;background:var(--border-color);margin:0 auto 14px;"></div>
                     <div style="font-size:16px;font-weight:800;color:var(--text-primary);margin-bottom:10px;">全量恢复：选择要导入的部分</div>
-                    <div style="font-size:12px;color:var(--text-secondary);margin-bottom:10px;">支持 v5 ZIP（推荐）、v4 JSON 与旧版；媒体从去重表或 ZIP 内 media/ 还原。</div>
                     <div style="display:flex;flex-direction:column;gap:10px;max-height:60vh;overflow:auto;padding-right:6px;">
                         ${categories.map(c => {
                             return `
@@ -463,6 +462,8 @@ async function importAllData(file) {
                     </div>
                 </div>
             `;
+            document.body.appendChild(overlay);
+            
             overlay.addEventListener('click', (ev) => { if (ev.target === overlay) { overlay.remove(); resolve(null); } });
             const fullImpCancelBtn = document.getElementById('full-imp-cancel');
             const fullImpConfirmBtn = document.getElementById('full-imp-confirm');
@@ -473,7 +474,6 @@ async function importAllData(file) {
                 overlay.remove();
                 resolve(selected);
             };
-            document.body.appendChild(overlay);
         });
 
         const selectedCats = await pickSelected();

--- a/js/utils.js
+++ b/js/utils.js
@@ -464,8 +464,10 @@ async function importAllData(file) {
                 </div>
             `;
             overlay.addEventListener('click', (ev) => { if (ev.target === overlay) { overlay.remove(); resolve(null); } });
-            document.getElementById('full-imp-cancel').onclick = () => { overlay.remove(); resolve(null); };
-            document.getElementById('full-imp-confirm').onclick = () => {
+            const fullImpCancelBtn = document.getElementById('full-imp-cancel');
+            const fullImpConfirmBtn = document.getElementById('full-imp-confirm');
+            if (fullImpCancelBtn) fullImpCancelBtn.onclick = () => { overlay.remove(); resolve(null); };
+            if (fullImpConfirmBtn) fullImpConfirmBtn.onclick = () => {
                 const selected = Array.from(overlay.querySelectorAll('input[type=checkbox]:checked'))
                     .map(i => i.dataset.cat);
                 overlay.remove();

--- a/js/utils.js
+++ b/js/utils.js
@@ -341,8 +341,8 @@ function applyGlobalThemeCss(cssCode) {
 
 async function exportAllData() {
     try {
-        if (typeof ChatBackup !== 'undefined' && ChatBackup.exportBackupToFile) {
-            await ChatBackup.exportBackupToFile({
+        if (typeof ChatBackup !== 'undefined' && ChatBackup.buildBackupPayload && ChatBackup.serializeBackupV4) {
+            const payload = await ChatBackup.buildBackupPayload({
                 inclMsgs: true,
                 inclSet: true,
                 inclCustom: true,
@@ -351,9 +351,15 @@ async function exportAllData() {
                 inclDg: true,
                 inclStickers: true
             });
-            return;
+            const jsonString = ChatBackup.serializeBackupV4(payload);
+            const dateStr = new Date().toISOString().slice(0, 10);
+            const fileName = `chatapp-backup-${dateStr}.json`;
+            const blob = new Blob([jsonString], { type: 'application/json;charset=utf-8' });
+            downloadFileFallback(blob, fileName);
+            if (typeof showNotification === 'function') showNotification('已导出 JSON 备份', 'success');
+        } else {
+            showNotification('备份模块或函数未加载，请刷新页面', 'error');
         }
-        showNotification('备份模块未加载', 'error');
     } catch (e) {
         console.error('全量导出失败:', e);
         showNotification('全量导出失败，请重试', 'error');


### PR DESCRIPTION
修复了onclick报错：在所有相关弹层（重置、导入、导出、歌单管理等）的 JS 文件中增加了判空逻辑，解决了在弹层节点未加载时，因直接绑定 `onclick` 导致的 `Cannot set properties of null` 错误。